### PR TITLE
Add Vagrant and Ansible deployment assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,23 @@ This work was conducted as part of my **MSc in Applied Cyber Security** at **Tec
 
 ---
 
+## 🚀 Deployment
+
+Spin up the virtual machines with Vagrant:
+
+```bash
+cd deploy
+vagrant up
+```
+
+Configure the Snort host using Ansible:
+
+```bash
+ansible-playbook deploy/snort.yml
+```
+
+---
+
 ## ⚙️ Lab Setup
 
 **Detection Machine (Snort IDS/IPS):**

--- a/deploy/Vagrantfile
+++ b/deploy/Vagrantfile
@@ -1,0 +1,13 @@
+Vagrant.configure("2") do |config|
+  config.vm.define "snort" do |snort|
+    snort.vm.box = "ubuntu/focal64"
+    snort.vm.hostname = "snort"
+    snort.vm.network "public_network"
+  end
+
+  config.vm.define "kali" do |kali|
+    kali.vm.box = "kalilinux/rolling"
+    kali.vm.hostname = "kali"
+    kali.vm.network "public_network"
+  end
+end

--- a/deploy/ansible/kali.yml
+++ b/deploy/ansible/kali.yml
@@ -1,0 +1,14 @@
+---
+- hosts: kali
+  become: yes
+  tasks:
+    - name: Update apt cache
+      apt:
+        update_cache: yes
+    - name: Install attack tools
+      apt:
+        name:
+          - snort
+          - wireshark
+          - nmap
+        state: present

--- a/deploy/ansible/snort.yml
+++ b/deploy/ansible/snort.yml
@@ -1,0 +1,14 @@
+---
+- hosts: snort
+  become: yes
+  tasks:
+    - name: Update apt cache
+      apt:
+        update_cache: yes
+    - name: Install Snort and tools
+      apt:
+        name:
+          - snort
+          - wireshark
+          - nmap
+        state: present

--- a/deploy/snort.yml
+++ b/deploy/snort.yml
@@ -1,0 +1,2 @@
+---
+- import_playbook: ansible/snort.yml


### PR DESCRIPTION
## Summary
- define Ubuntu (Snort) and Kali (attack) VMs with bridged networking via Vagrant
- add Ansible playbooks to install Snort, Wireshark, and Nmap on each VM
- document `vagrant up` and `ansible-playbook deploy/snort.yml` usage

## Testing
- `ansible-playbook --syntax-check deploy/snort.yml`
- `ansible-playbook --syntax-check deploy/ansible/kali.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b49b7923ec833095033970d5b6a7e8